### PR TITLE
Bug Fix: Anchor AWS secret key match to EoF.

### DIFF
--- a/rules/credential/cloud/aws/secret_key.yar
+++ b/rules/credential/cloud/aws/secret_key.yar
@@ -3,7 +3,7 @@ rule CredentialCloudAWSSecretKey : Credential Cloud AWS {
     meta:
         name        = "AWS Secret Key"
         author      = "Peter Adkins"
-        version     = "0.4.0"
+        version     = "0.4.1"
         accuracy    = 80
         description = "Potential AWS Secret key found."
 
@@ -15,14 +15,14 @@ rule CredentialCloudAWSSecretKey : Credential Cloud AWS {
         $secret_0 = { (0D | 0A | 22 | 27 | 3D | 20 | 2C | 3B | 60 | 00 | 3A | 5C 6E | 5C 72) [40] (0D | 0A | 22 | 27 | 3D | 20 | 2C | 3B | 60 | 00 | 3A | 5C 6E | 5C 72) }
 
         $access_1 = { 41 (4B | 53) 49 41 [15] ?? } private
-        $secret_1 = /[A-Za-z0-9\+\/=]{40}$/ ascii wide
+        $secret_1 = { (0D | 0A | 22 | 27 | 3D | 20 | 2C | 3B | 60 | 00 | 3A | 5C 6E | 5C 72) [39] ?? }
     
     condition:
         any of ($atom_*) and (
             (
                 $access_0 and $secret_0
             ) or (
-                $access_1 and $secret_1
+                $access_1 and $secret_1 in (filesize - 41..filesize)
             )
         )
 }


### PR DESCRIPTION
## Overview

This pull-request ensures that the AWS Secret Key match is anchored to EoF for this particular pattern. It also ensures that it is proceeded by a more reliably set of characters to reduce false positives.
